### PR TITLE
fix two globstars in the middle of a path

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ var REPLACERS = [
     // > the same as pattern "foo". 
     // > "**/foo/bar" matches file or directory "bar" anywhere that is directly under directory "foo".
     // Notice that the '*'s have been replaced as '\\*'
-    /\\\*\\\*\\\//,
+    /^\^*\\\*\\\*\\\//,
 
     // '**/foo' <-> 'foo'
     // just remove it
@@ -253,7 +253,7 @@ var REPLACERS = [
     // > A slash followed by two consecutive asterisks then a slash matches zero or more directories. 
     // > For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b" and so on.
     // '/**/'
-    /\/\\\*\\\*\//g,
+    /\\\/\\\*\\\*\\\//g,
 
     // Zero, one or several directories
     // should not use '*', or it will be replaced by the next replacer

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -55,6 +55,33 @@ describe(".makeRegex(), normal options, pattern '**/foo' matches 'foo' anywhere:
   });
 });
 
+
+describe(".makeRegex(), normal options, pattern '/**/foo' matches 'foo' anywhere:", function () {
+    var ig = ignore();
+    var r_foo = ig.makeRegex('/**/foo');
+    
+    it("should match 'foo'", function () {
+        expect(r_foo.test('foo')).to.equal(true);
+    });
+    
+    it("should match 'foo/'", function () {
+        expect(r_foo.test('foo/')).to.equal(true);
+    });
+    
+    it("should match '/foo'", function () {
+        expect(r_foo.test('/foo')).to.equal(true);
+    });
+    
+    it("should not match 'fooo'", function () {
+        expect(r_foo.test('fooo')).to.equal(false);
+    });
+    
+    it("should not match 'ofoo'", function () {
+        expect(r_foo.test('ofoo')).to.equal(false);
+    });
+});
+
+
 describe(".makeRegex(), normal options, pattern 'foo/':", function() {
   var ig = ignore();
   var r_foo_slash = ig.makeRegex('foo/');
@@ -177,6 +204,38 @@ describe(".makeRegex(), normal options, pattern 'foo/**/':", function() {
   it("should not match '/foo'", function() {
     expect(r_foo_globstar_slash.test('/foo')).to.equal(false);
   });
+});
+
+
+describe(".makeRegex(), normal options, pattern 'foo/**/*.bar':", function () {
+    var ig = ignore();
+    var r_foo_globstar_path = ig.makeRegex('foo/**/*.bar');
+
+    console.log(r_foo_globstar_path);
+    
+    it("should not match 'foo/'", function () {
+        expect(r_foo_globstar_path.test('foo/')).to.equal(false);
+    });
+    
+    it("should not match 'abc.bar'", function () {
+        expect(r_foo_globstar_path.test('abc.bar')).to.equal(false);
+    });
+    
+    it("should match 'foo/abc.bar'", function () {
+        expect(r_foo_globstar_path.test('foo/abc.bar')).to.equal(true);
+    });
+    
+    it("should match 'foo/abc.bar/'", function () {
+        expect(r_foo_globstar_path.test('foo/abc.bar/')).to.equal(true);
+    });
+    
+    it("should match 'foo/x/y/z.bar'", function () {
+        expect(r_foo_globstar_path.test('foo/x/y/z.bar')).to.equal(true);
+    });
+    
+    it("should match 'foo/x/y/z.bar/'", function () {
+        expect(r_foo_globstar_path.test('foo/x/y/z.bar/')).to.equal(true);
+    });
 });
 
 


### PR DESCRIPTION
I noticed a bug concerning two globstars in the middle of a path. In the tests, this is actually explicitly mentioned to work (although this was not tested explicitly):

    For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b" and so on.

However, the problem was that the replacer for two globstars at the beginning just replaced the first globstars it matched and NOT only at the beginning. Then the replacer for the inbetween-globstars did not take into account that the forward slashes have been escaped by a backslash as well.

In the pull request, I fixed it and added more tests to cover these cases.

Please accept the pull request and release a new npm package version.

Thanks