### PR TITLE
Accept Ignore as argument of .add

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -32,18 +32,23 @@ var IgnoreBase = function () {
       this._cache = {};
     }
 
-    // @param {Array.<string>|string} pattern
+    // @param {Array.<string>|string|Ignore} pattern
 
   }, {
     key: 'add',
     value: function add(pattern) {
       this._added = false;
 
-      if (typeof pattern === 'string') {
-        pattern = pattern.split(/\r?\n/g);
-      }
+      if (pattern instanceof IgnoreBase) {
+        this._rules = this._rules.concat(pattern._rules);
+        this._added = true;
+      } else {
+        if (typeof pattern === 'string') {
+          pattern = pattern.split(/\r?\n/g);
+        }
 
-      make_array(pattern).forEach(this._addPattern, this);
+        make_array(pattern).forEach(this._addPattern, this);
+      }
 
       // Some rules have just added to the ignore,
       // making the behavior changed.

--- a/index.js
+++ b/index.js
@@ -27,15 +27,20 @@ class IgnoreBase {
     this._cache = {}
   }
 
-  // @param {Array.<string>|string} pattern
+  // @param {Array.<string>|string|Ignore} pattern
   add (pattern) {
     this._added = false
 
-    if (typeof pattern === 'string') {
-      pattern = pattern.split(/\r?\n/g)
-    }
+    if (pattern instanceof IgnoreBase) {
+      this._rules = this._rules.concat(pattern._rules)
+      this._added = true;
+    } else {
+      if (typeof pattern === 'string') {
+        pattern = pattern.split(/\r?\n/g)
+      }
 
-    make_array(pattern).forEach(this._addPattern, this)
+      make_array(pattern).forEach(this._addPattern, this)
+    }
 
     // Some rules have just added to the ignore,
     // making the behavior changed.

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -457,6 +457,20 @@ describe("cases", function() {
       expect_result(result, make_win32)
     })
   })
+
+  it('.add(<Ignore>)', function() {
+    var a = ignore().add(['.abc/*', '!.abc/d/'])
+    var b = ignore().add(a).add('!.abc/e/')
+
+    var paths = [
+      '.abc/a.js',    // filtered out
+      '.abc/d/e.js',   // included
+      '.abc/e/e.js'   // included by b, filtered out by a
+    ]
+
+    expect(a.filter(paths)).to.eql([ '.abc/d/e.js' ]);
+    expect(b.filter(paths)).to.eql([ '.abc/d/e.js', '.abc/e/e.js' ]);
+  })
 })
 
 function make_win32 (path) {


### PR DESCRIPTION
This PR makes it possible to inherit the rules of another `Ignore` instance:

```js
const ignore = require('ignore')

var a = ignore().add(['.abc/*', '!.abc/d/'])
var b = ignore().add(a).add('!.abc/e/')

var paths = [
  '.abc/a.js',    // filtered out
  '.abc/d/e.js',   // included
  '.abc/e/e.js'   // included by b, filtered out by a
]

a.filter(paths)  // ['.abc/d/e.js']
b.filter(paths)  // [ '.abc/d/e.js', '.abc/e/e.js' ]
```