### PR TITLE
Declare `ignore` as default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,4 +38,4 @@ interface Ignore {
  */
 declare function ignore(): Ignore
 
-export = ignore 
+export default ignore


### PR DESCRIPTION
This fixes compatibility with TypeScript used in combination with ESM. Currently, the only way to import `ignore` in TypeScript is through the `import * as X from Y` construct, even though `ignore` is actually a default export through the use of `module.exports = X`. When used in combination with ESM, this would lead to `ignore` being imported as an object with a `default` property.