### PR TITLE
Fix exporting of ignore object in typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,14 @@ Since `4.0.0`, ignore will no longer support `node < 6` by default, to use in no
 
 ## Usage
 
+JS:
 ```js
 import ignore from 'ignore'
+const ig = ignore().add(['.abc/*', '!.abc/d/'])
+```
+Typescript:
+```typescript
+import * as ignore from 'ignore'
 const ig = ignore().add(['.abc/*', '!.abc/d/'])
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,4 +60,4 @@ declare namespace ignore {
   export function isPathValid (pathname: string): boolean
 }
 
-export default ignore
+export = ignore

--- a/test/ts/simple.ts
+++ b/test/ts/simple.ts
@@ -1,4 +1,4 @@
-import ignore from '../../'
+import * as ignore from '../../'
 
 const paths = ['a', 'a/b', 'foo/bar']
 


### PR DESCRIPTION
The export default construct adds the export to a .default object, which
typescript thens tries to call, which doesn't exist. Changing the export
from default to `export =` means that the module can be imported `import *
as ignore from 'ignore'`, and everythig works out.

Signed-off-by: Cameron Diver <cameron@resin.io>