### PR TITLE
Fix paths with supported unicode chars not converted to posix

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,7 +547,7 @@ if (
 
   /* eslint no-control-regex: "off" */
   const make_posix = str => /^\\\\\?\\/.test(str)
-  || /[^\x00-\x80]+/.test(str)
+  || /["<>|\u0000-\u001F]+/u.test(str)
     ? str
     : str.replace(/\\/g, '/')
 

--- a/test/fixtures/cases.js
+++ b/test/fixtures/cases.js
@@ -806,6 +806,18 @@ const cases = [
       'node_modules/gulp/node_modules/abc.md': 1,
       'node_modules/gulp/node_modules/abc.json': 1
     }
+  ],
+  [
+    'unicode characters in windows paths',
+    [
+      'test'
+    ],
+    {
+      'some/path/to/test/ignored.js': 1,
+      'some/special/path/to/目录/test/ignored.js': 1
+    },
+    false,
+    true // git-check-ignore fails as git converts special chars to escaped unicode before printing
   ]
 ]
 


### PR DESCRIPTION
This was raised as an issue in eslint where certain files weren't being ignored [due to special characters being present in the pathname](https://github.com/eslint/eslint/issues/10821).

Windows supports a lot more unicode characters in its pathnames than we assume in the `make_posix` function which limits supported characters to the standard ASCII set. Looks like we only need to check for a few control characters as per https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#naming-conventions

[I've based my implementation on .NET system io library.](https://referencesource.microsoft.com/#mscorlib/system/io/pathinternal.cs,32)