### PR TITLE
Export Ignore interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ interface TestResult {
   unignored: boolean
 }
 
-interface Ignore {
+export interface Ignore {
   /**
    * Adds a rule rules to the current manager.
    * @param  {string | Ignore} pattern


### PR DESCRIPTION
Exports `Ignore` interface to allow importing it in TypeScript projects.