### PR TITLE
fix: support file which named '...'

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ const REGEX_SPLITALL_CRLF = /\r?\n/g
 // ../foo,
 // .
 // ..
-const REGEX_TEST_INVALID_PATH = /^\.*\/|^\.+$/
+
+const REGEX_TEST_INVALID_PATH = /^\.{0,2}\/|^\.{1,2}$/
 
 const SLASH = '/'
 const KEY_IGNORE = typeof Symbol !== 'undefined'

--- a/test/others.js
+++ b/test/others.js
@@ -188,6 +188,12 @@ const IGNORE_TEST_CASES = [
     ['*.js', '!a/a.js'],
     'a/a.js',
     [false, true]
+  ],
+  [
+    `test: file which named '...'`,
+    'foo',
+    '...',
+    [false, false]
   ]
 ]
 


### PR DESCRIPTION
`...` or more then two dots may be a file

but throw Error like `RangeError: path should be a path.relative()d string, but got "..."` now.