### PR TITLE
chore: export `Options` interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ export interface Ignore {
   test(pathname: Pathname): TestResult
 }
 
-interface Options {
+export interface Options {
   ignorecase?: boolean
   // For compatibility
   ignoreCase?: boolean


### PR DESCRIPTION
This PR allows typing external methods which expect `Options` as a param, by importing the `Options` interface.

cc @kaelzhang 