### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:kaelzhang/node-ignore.git"
+    "url": "https://github.com/kaelzhang/node-ignore.git"
   },
   "keywords": [
     "ignore",


### PR DESCRIPTION
## Summary

Update the npm package repository metadata from scp-style SSH to a public HTTPS GitHub URL.

The published `ignore@7.0.5` package currently exposes:

```json
"repository": {
  "type": "git",
  "url": "git@github.com:kaelzhang/node-ignore.git"
}
```

That form requires SSH/GitHub key setup for consumers and metadata tools that try to resolve the repository URL. This PR keeps the same repository and changes only the URL scheme:

```json
"url": "https://github.com/kaelzhang/node-ignore.git"
```

## Validation

- `node -e 'const p=require("./package.json"); if (p.repository.url !== "https://github.com/kaelzhang/node-ignore.git") process.exit(1)'`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json .`
