### PR TITLE
fix: negated character class [!...] should match like git

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,15 @@ const sanitizeRange = range => range.replace(
     : EMPTY
 )
 
+// > An optional `!` or `^` at the start of a class negates it, so that it
+// >   matches any character not in the set. (gitignore(5), fnmatch(3))
+// The leading `^` has already been escaped to `\^` by the metacharacter
+//   escaper, so we strip the literal `!` or escaped `^` and emit a single
+//   regex `^` which is the JavaScript negation token.
+const negateRange = range => range.startsWith('!') || range.startsWith('\\^')
+  ? `^${range.slice(range[0] === '!' ? 1 : 2)}`
+  : range
+
 // See fixtures #59
 const cleanRangeBackSlash = slashes => {
   const {length} = slashes
@@ -272,7 +281,7 @@ const REPLACERS = [
           // A normal case, and it is a range notation
           // '[bar]'
           // '[bar\\\\]'
-          ? `[${sanitizeRange(range)}${endEscape}]`
+          ? `[${negateRange(sanitizeRange(range))}${endEscape}]`
           // Invalid range notaton
           // '[bar\\]' -> '[bar\\\\]'
           : '[]'

--- a/test/fixtures/cases.js
+++ b/test/fixtures/cases.js
@@ -390,6 +390,63 @@ const cases = [
     }
   ],
   [
+    // A class starting with `!` or `^` is negated and matches any
+    //   character not in the set, same as fnmatch(3) / git check-ignore
+    'negated class: [!a].txt',
+    [
+      '[!a].txt'
+    ],
+    {
+      'a.txt': 0,
+      'b.txt': 1
+    }
+  ],
+  [
+    'negated class with caret: [^a]',
+    [
+      '[^a]'
+    ],
+    {
+      'a': 0,
+      'b': 1
+    }
+  ],
+  [
+    'negated range: [!a-c].txt',
+    [
+      '[!a-c].txt'
+    ],
+    {
+      'a.txt': 0,
+      'b.txt': 0,
+      'c.txt': 0,
+      'd.txt': 1
+    }
+  ],
+  [
+    'negated numeric range: [!0-9]',
+    [
+      '[!0-9]'
+    ],
+    {
+      '0': 0,
+      '5': 0,
+      '9': 0,
+      'a': 1
+    }
+  ],
+  [
+    'negated class in the middle: x[!y]z',
+    [
+      'x[!y]z'
+    ],
+    {
+      'xyz': 0,
+      'xaz': 1,
+      'xbz': 1
+    }
+  ],
+  [
     'special case: similar, but not a character set',
     [
       '*.[a-'


### PR DESCRIPTION
## The bug

A character class that begins with `!` or `^` is compiled to a *positive*
regex class, so matching is the exact logical inverse of `git check-ignore`.

```js
const ignore = require('ignore')

ignore().add('[!a].txt').ignores('a.txt') // true  (git: NOT ignored)
ignore().add('[!a].txt').ignores('b.txt') // false (git: ignored)
```

Same inversion for `[^a]`, `[!a-c]`, `[!0-9]`, and a class in the middle of a
pattern such as `x[!y]z`.

## Ground truth

gitignore(5) defers to fnmatch(3): a class whose first character is `!` or `^`
is negated and matches any single character not in the set. Verified against
git 2.50.1 with non-verbose `git check-ignore` (exit 0 means ignored):

```
$ printf '[!a].txt\n' > .gitignore
$ git check-ignore -q a.txt; echo $?   # 1  -> NOT ignored
$ git check-ignore -q b.txt; echo $?   # 0  -> ignored
```

So `[!a].txt` ignores `b.txt` but not `a.txt`, which is the opposite of what
this library returned.

## Root cause and fix

The range replacer in `index.js` emits the class content as a positive class
and never turns a leading `!` / `^` into a regex negation:

```js
? `[${sanitizeRange(range)}${endEscape}]`
```

There is a subtle ordering detail. The metacharacter escaper runs earlier and
escapes a bare `^` to `\^`, while `!` is left untouched. So by the time the
range replacer runs, the class content starts with either a literal `!` or an
escaped `\^`. The fix strips that leading token and emits a single regex `^`,
which is the JavaScript negation token:

```js
const negateRange = range => range.startsWith('!') || range.startsWith('\\^')
  ? `^${range.slice(range[0] === '!' ? 1 : 2)}`
  : range
```

```js
? `[${negateRange(sanitizeRange(range))}${endEscape}]`
```

This affects both `.ignores()` and `.checkIgnore()`, since both go through the
same compiled regex.

## Tests

Added fixture cases next to the existing range-notation cases covering
`[!a].txt`, `[^a]`, `[!a-c].txt`, `[!0-9]`, and `x[!y]z`. They fail before the
change (returning the inverted result) and pass after it. Existing positive
class and range cases (`[abc]`, `[a-z]`, escaped `\[a\]`, the #59 cases) keep
passing; coverage stays at 100%.

Related: #155 lists a negated-class divergence among several gitignore
discrepancies. This change covers negated classes with content; the empty
`[!]` edge case from that issue is left as is.
