### PR TITLE
fix: consecutive leading `**/` should match like a single `**/`

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ const REPLACERS = [
     // > "**/foo/bar" matches file or directory "bar" anywhere that is directly
     // >   under directory "foo".
     // Notice that the '*'s have been replaced as '\\*'
-    /^\^*\\\*\\\*\\\//,
+    /^\^*(?:\\\*\\\*\\\/)+/,
 
     // '**/foo' <-> 'foo'
     () => '^(?:.*\\/)?'

--- a/test/fixtures/cases.js
+++ b/test/fixtures/cases.js
@@ -871,6 +871,18 @@ const cases = [
   ],
 
   [
+    'consecutive leading "**/" behave as a single "**/"',
+    [
+      '**/**/foo'
+    ],
+    {
+      'foo': 1,
+      'a/foo': 1,
+      'a/b/foo': 1
+    }
+  ],
+
+  [
     '"**/foo/bar" matches file or directory "bar" anywhere that is directly under directory "foo"',
     [
       '**/foo/bar'


### PR DESCRIPTION
A pattern with consecutive leading globstars such as `**/**/foo` fails to match `foo` at the repository root, while `git check-ignore` matches it.

```js
ignore().add('**/**/foo').ignores('foo')      // false, should be true
ignore().add('**/**/foo').ignores('a/foo')    // true (correct)
```

```
$ printf '**/**/foo\n' > .gitignore
$ git check-ignore --no-index foo
foo
```

Only the root case is wrong; `a/foo` and `a/b/foo` already match. Git treats a run of leading `**/` the same as a single `**/` ("match in all directories", including zero), so `**/**/foo` is equivalent to `**/foo`.

Cause: the leading-globstar replacer only consumes the first `**/`. The remaining `**/` is then handled as an ordinary `**`, which forces at least one intermediate directory and drops the root match.

Fix: let the replacer consume one or more consecutive leading `**/` runs. `**/**/foo` now compiles to the same regex as `**/foo`.

Adds a regression test to `test/fixtures/cases.js` (exercised by `.ignores()`, `.filter()`, `.checkIgnore()` and the `git check-ignore` fixture oracle).
