### PR TITLE
fix: translate a bracket expression by its own sub-grammar

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,34 +42,223 @@ const define = (object, key, value) => {
   return value
 }
 
-const REGEX_REGEXP_RANGE = /([0-z])-([0-z])/g
-
 const RETURN_FALSE = () => false
-
-// Sanitize the range of a regular expression
-// The cases are complicated, see test cases for details
-const sanitizeRange = range => range.replace(
-  REGEX_REGEXP_RANGE,
-  (match, from, to) => from.charCodeAt(0) <= to.charCodeAt(0)
-    ? match
-    // Invalid range (out of order) which is ok for gitignore rules but
-    //   fatal for JavaScript regular expression, so eliminate it.
-    : EMPTY
-)
-
-// > An optional `!` or `^` at the start of a class negates it, so that it
-// >   matches any character not in the set. (gitignore(5), fnmatch(3))
-// The leading `^` has already been escaped to `\^` by the metacharacter
-//   escaper, so we strip the literal `!` or escaped `^` and emit a single
-//   regex `^` which is the JavaScript negation token.
-const negateRange = range => range.startsWith('!') || range.startsWith('\\^')
-  ? `^${range.slice(range[0] === '!' ? 1 : 2)}`
-  : range
 
 // See fixtures #59
 const cleanRangeBackSlash = slashes => {
   const {length} = slashes
   return slashes.slice(0, length - length % 2)
+}
+
+// > The range notation, e.g. [a-zA-Z],
+// > can be used to match one of the characters in a range.
+//
+// gitignore(5) defers to fnmatch(3) for this, and git implements it in
+//   `wildmatch.c`.  A bracket expression has a sub-grammar of its own, which
+//   is neither the surrounding pattern grammar nor the JavaScript one:
+//
+//   - a `]` right after `[` or `[!` is a literal member, not the terminator
+//   - `[:alpha:]` names one of twelve POSIX classes
+//   - `\` escapes the next member, `]` included
+//   - `*`, `?` and `.` are plain literal members
+//   - an unterminated expression makes the whole pattern match nothing
+//
+// which means the expression can not be located -- let alone translated -- by
+//   a regular expression.  It is scanned out of the pattern before the
+//   replacers below run, and put back once they are done, so that neither the
+//   metacharacter escaper nor the `?` / `*` replacers ever see its body.
+
+// git classifies with its own ASCII-only ctype macros (`wildmatch.c`), never
+//   with the C library ones, so these must not be mapped onto `\d` / `\w` /
+//   `\s`, which are wider.  `/` is left out of every expansion, because a
+//   bracket expression never matches a path separator.
+const POSIX_CLASSES = {
+  alnum: '0-9A-Za-z',
+  alpha: 'A-Za-z',
+  blank: ' \\t',
+  cntrl: '\\x00-\\x1f\\x7f',
+  digit: '0-9',
+  graph: '!-.0-~',
+  lower: 'a-z',
+  print: ' -.0-~',
+  punct: '!-.:-@\\[-`{-~',
+  // git's `sane-ctype.h` classifies \v and \f as control, not space,
+  //   unlike C's `isspace`
+  space: ' \\t\\n\\r',
+  upper: 'A-Z',
+  xdigit: '0-9A-Fa-f'
+}
+
+const CLASS_MEMBERS_TO_ESCAPE = '\\]^-['
+
+const escapeMember = char => CLASS_MEMBERS_TO_ESCAPE.indexOf(char) < 0
+  ? char
+  : ESCAPE + char
+
+// Scan the bracket expression that starts at `pattern[start] === '['`,
+//   mirroring the member loop of git's `wildmatch.c`.
+// @returns {{end: number, source: string} | null} `null` if the expression is
+//   never terminated, which makes the whole pattern match nothing.
+const scanBracket = (pattern, start) => {
+  const {length} = pattern
+  let index = start + 1
+  let negated = EMPTY
+
+  const lead = pattern[index]
+  if (lead === '!' || lead === '^') {
+    negated = '^'
+    index ++
+  }
+
+  let body = EMPTY
+
+  // The member a `-` could start a range from, or EMPTY when the previous
+  //   member can not open one (start of the body, or a range / POSIX class
+  //   that has just closed)
+  let prev = EMPTY
+
+  // git scans the members with a do-while, so the first one is consumed
+  //   unconditionally.  That is the whole reason a leading `]` is a member
+  //   and not the terminator.
+  for (;;) {
+    const char = pattern[index]
+
+    if (char === UNDEFINED) {
+      return null
+    }
+
+    if (char === ESCAPE) {
+      const escaped = pattern[index + 1]
+      if (escaped === UNDEFINED) {
+        return null
+      }
+      body += escapeMember(escaped)
+      prev = escaped
+      index ++
+    } else if (
+      char === '-'
+      && prev
+      && index + 1 < length
+      && pattern[index + 1] !== ']'
+    ) {
+      index ++
+      let to = pattern[index]
+      if (to === ESCAPE) {
+        // A pattern can not end on a lone backslash -- `checkPattern` has
+        //   already thrown it away -- so there is an upper bound to read.
+        to = pattern[index += 1]
+      }
+      // An out-of-order range matches nothing in git but is a syntax error in
+      //   JavaScript, so it is dropped.  Its lower bound stays: git tests it
+      //   as a plain member before it ever looks at the `-`, so `[c-a]` does
+      //   match `c`.
+      if (prev <= to) {
+        body += `-${escapeMember(to)}`
+      }
+      prev = EMPTY
+    } else if (char === '[' && pattern[index + 1] === ':') {
+      const nameStart = index + 2
+      let end = nameStart
+      while (end < length && pattern[end] !== ']') {
+        end ++
+      }
+
+      if (end === length) {
+        return null
+      }
+
+      if (end > nameStart && pattern[end - 1] === ':') {
+        const expanded = POSIX_CLASSES[pattern.slice(nameStart, end - 1)]
+
+        // An unknown class name makes the whole pattern match nothing
+        if (expanded === UNDEFINED) {
+          return null
+        }
+
+        body += expanded
+        prev = EMPTY
+        index = end
+      } else {
+        // No `:]` to close it, so the `[` is a plain member and scanning
+        //   resumes right after it.
+        body += escapeMember('[')
+        prev = '['
+        index = nameStart - 2
+      }
+    } else {
+      body += escapeMember(char)
+      prev = char
+    }
+
+    index ++
+
+    if (pattern[index] === ']') {
+      return {
+        end: index,
+        source: `[${negated}${body}]`
+      }
+    }
+  }
+}
+
+// An empty JavaScript class can never match, which is how a pattern that git
+//   gives up on (`WM_ABORT_ALL`) is expressed here.
+const NEVER_MATCH = '[]'
+
+// A NUL can appear in neither a `.gitignore` line nor a path, which makes it
+//   the one safe placeholder character.  A literal one in the pattern is
+//   held aside all the same, so a collision is impossible by construction.
+const PLACEHOLDER = '\u0000'
+const REGEX_RESTORE_PLACEHOLDER = new RegExp(
+  `${PLACEHOLDER}(\\d+)${PLACEHOLDER}`, 'g'
+)
+
+// Replace every bracket expression with a placeholder the replacers below
+//   leave alone, and translate it separately.
+const extractBrackets = pattern => {
+  const sources = []
+  const hold = source =>
+    `${PLACEHOLDER}${sources.push(source) - 1}${PLACEHOLDER}`
+
+  const {length} = pattern
+  let out = EMPTY
+  let index = 0
+
+  while (index < length) {
+    const char = pattern[index]
+
+    if (char === ESCAPE) {
+      // An escaped `[` is a literal one; leave the pair to the replacers,
+      //   which already deal with `\[foo]`.
+      out += pattern.slice(index, index + 2)
+      index += 2
+    } else if (char === PLACEHOLDER) {
+      // Hold a literal placeholder character aside as well, so that pattern
+      //   text can never be mistaken for a placeholder we emitted.
+      out += hold(`[${PLACEHOLDER}]`)
+      index ++
+    } else if (char === '[') {
+      const scanned = scanBracket(pattern, index)
+
+      if (scanned === null) {
+        // git gives up on the whole pattern (`WM_ABORT_ALL`), so whatever
+        //   follows can not make it match either.
+        out += hold(NEVER_MATCH)
+        index = length
+      } else {
+        out += hold(scanned.source)
+        index = scanned.end + 1
+      }
+    } else {
+      out += char
+      index ++
+    }
+  }
+
+  return {
+    source: out,
+    sources
+  }
 }
 
 // > If the pattern ends with a slash,
@@ -268,24 +457,16 @@ const REPLACERS = [
   ],
 
   [
-    // > The range notation, e.g. [a-zA-Z],
-    // > can be used to match one of the characters in a range.
+    // Every real bracket expression has already been held aside by
+    //   `extractBrackets`, so the only `[` left in the pattern is an escaped,
+    //   literal one.
 
     // `\` is escaped by step 3
-    /(\\)?\[([^\]/]*?)(\\*)($|\])/g,
-    (match, leadEscape, range, endEscape, close) => leadEscape === ESCAPE
-      // '\\[bar]' -> '\\\\[bar\\]'
-      ? `\\[${range}${cleanRangeBackSlash(endEscape)}${close}`
-      : close === ']'
-        ? endEscape.length % 2 === 0
-          // A normal case, and it is a range notation
-          // '[bar]'
-          // '[bar\\\\]'
-          ? `[${negateRange(sanitizeRange(range))}${endEscape}]`
-          // Invalid range notaton
-          // '[bar\\]' -> '[bar\\\\]'
-          : '[]'
-        : '[]'
+    /\\\[([^\]/]*?)(\\*)($|\])/g,
+
+    // '\\[bar]' -> '\\\\[bar\\]'
+    (match, range, endEscape, close) =>
+      `\\[${range}${cleanRangeBackSlash(endEscape)}${close}`
   ],
 
   // ending
@@ -353,11 +534,16 @@ const TRAILING_WILD_CARD_REPLACERS = {
 }
 
 // @param {pattern}
-const makeRegexPrefix = pattern => REPLACERS.reduce(
-  (prev, [matcher, replacer]) =>
-    prev.replace(matcher, replacer.bind(pattern)),
-  pattern
-)
+const makeRegexPrefix = pattern => {
+  const {source, sources} = extractBrackets(pattern)
+
+  return REPLACERS.reduce(
+    (prev, [matcher, replacer]) =>
+      prev.replace(matcher, replacer.bind(pattern)),
+    source
+  )
+  .replace(REGEX_RESTORE_PLACEHOLDER, (match, index) => sources[index])
+}
 
 const isString = subject => typeof subject === 'string'
 

--- a/test/fixtures/cases.js
+++ b/test/fixtures/cases.js
@@ -351,7 +351,8 @@ const cases = [
     }
   ],
   [
-    // If range is out of order, then omitted
+    // An out of order range matches nothing, but git tests the lower bound as
+    //   a plain member before it ever looks at the `-`, so `a` still matches
     'special case: range out of order: [a-9]',
     [
       '*.[a-9]'
@@ -359,7 +360,8 @@ const cases = [
     {
       'a.0': 0,
       'a.-': 0,
-      'a.9': 0
+      'a.9': 0,
+      'a.a': 1
     }
   ],
   [
@@ -466,6 +468,233 @@ const cases = [
       'a.[': 0,
       'a.a': 0,
       'a.-': 0
+    }
+  ],
+  // A bracket expression has a sub-grammar of its own (gitignore(5) ->
+  //   fnmatch(3) -> git/wildmatch.c).  Every expectation below is what
+  //   `git check-ignore` answers, and test/git-check-ignore.test.js re-checks
+  //   each of them against the real git binary.
+  [
+    'POSIX character classes: [[:alpha:]] and friends',
+    [
+      'alnum[[:alnum:]]x',
+      'alpha[[:alpha:]]x',
+      'blank[[:blank:]]x',
+      'digit[[:digit:]]x',
+      'graph[[:graph:]]x',
+      'lower[[:lower:]]x',
+      'print[[:print:]]x',
+      'punct[[:punct:]]x',
+      'space[[:space:]]x',
+      'upper[[:upper:]]x',
+      'xdigit[[:xdigit:]]x'
+    ],
+    {
+      'alnum7x': 1,
+      'alnum-x': 0,
+      'alphazx': 1,
+      'alpha0x': 0,
+      'blank x': 1,
+      'blank-x': 0,
+      'digit0x': 1,
+      'digitzx': 0,
+      'graph-x': 1,
+      'graph x': 0,
+      'lowerzx': 1,
+      'lower-x': 0,
+      'print x': 1,
+      'print-x': 1,
+      'punct-x': 1,
+      'punctzx': 0,
+      'space x': 1,
+      'space-x': 0,
+      // git's sane-ctype classifies \v and \f as control, not space
+      'space\u000bx': 0,
+      'space\fx': 0,
+      'upperQx': 1,
+      'upper-x': 0,
+      'xdigitfx': 1,
+      'xdigitzx': 0
+    }
+  ],
+  [
+    'a POSIX class never matches a slash',
+    [
+      'a/b[[:print:]]c'
+    ],
+    {
+      'a/b/c': 0,
+      'a/b-c': 1
+    }
+  ],
+  [
+    'negated POSIX class',
+    [
+      'neg[![:digit:]]x',
+      'caret[^[:digit:]]x'
+    ],
+    {
+      'neg0x': 0,
+      'negzx': 1,
+      'neg-x': 1,
+      'caret0x': 0,
+      'caretzx': 1
+    }
+  ],
+  [
+    'POSIX class combined with literals and with another class',
+    [
+      'set[[:digit:]abc]x',
+      'two[[:digit:][:upper:]]x'
+    ],
+    {
+      'set0x': 1,
+      'setbx': 1,
+      'setzx': 0,
+      'two0x': 1,
+      'twoQx': 1,
+      'two-x': 0
+    }
+  ],
+  [
+    'unknown POSIX class name matches nothing',
+    [
+      '*.[[:foo:]]'
+    ],
+    {
+      'a.0': 0,
+      'a.a': 0,
+      'a.f]': 0,
+      'a.[]': 0
+    }
+  ],
+  [
+    '[:name] without the closing :] is a plain character set',
+    [
+      '*.[[:alpha]]'
+    ],
+    {
+      'a.a]': 1,
+      'a.[]': 1,
+      'a.z]': 0,
+      'a.a': 0
+    }
+  ],
+  [
+    '] as the first member of a class',
+    [
+      '*.[]]',
+      'x[]a]y'
+    ],
+    {
+      'a.]': 1,
+      'a.a': 0,
+      'x]y': 1,
+      'xay': 1,
+      'xby': 0
+    }
+  ],
+  [
+    '] as the first member of a negated class',
+    [
+      '*.[!]]'
+    ],
+    {
+      'a.]': 0,
+      'a.a': 1,
+      'a.0': 1
+    }
+  ],
+  [
+    'escaped members of a class',
+    [
+      '*.[\\]]',
+      'x[\\^]y',
+      'n[a\\-c]m'
+    ],
+    {
+      'a.]': 1,
+      'a.a': 0,
+      'x^y': 1,
+      'xay': 0,
+      'nam': 1,
+      'n-m': 1,
+      'ncm': 1,
+      'nbm': 0
+    }
+  ],
+  [
+    'a regular expression metacharacter is a literal class member',
+    [
+      '*.[*]',
+      'x[?]y',
+      'n[a*b]m'
+    ],
+    {
+      'a.*': 1,
+      'a.a': 0,
+      'a.]': 0,
+      'a.[]': 0,
+      'x?y': 1,
+      'xay': 0,
+      'nam': 1,
+      'n*m': 1,
+      'nzm': 0
+    }
+  ],
+  [
+    '[ as a literal class member',
+    [
+      '*.[[]'
+    ],
+    {
+      'a.[': 1,
+      'a.a': 0
+    }
+  ],
+  [
+    'escaped range bound',
+    [
+      '*.[a-\\c]'
+    ],
+    {
+      'a.a': 1,
+      'a.b': 1,
+      'a.c': 1,
+      'a.d': 0
+    }
+  ],
+  [
+    'unterminated class after an escaped backslash',
+    [
+      '*.[a\\\\\\'
+    ],
+    {
+      'a.a': 0,
+      'a.b': 0
+    }
+  ],
+  [
+    // #155
+    'empty negated class: [!]',
+    [
+      '[!]'
+    ],
+    {
+      '!': 0,
+      'a': 0,
+      ']': 0
+    }
+  ],
+  [
+    'unterminated POSIX class',
+    [
+      '*.[[:alpha:'
+    ],
+    {
+      'a.a': 0,
+      'a.z': 0,
+      'a.[': 0
     }
   ],
   [

--- a/test/others.test.js
+++ b/test/others.test.js
@@ -243,6 +243,20 @@ IGNORE_TEST_CASES.forEach(([d, patterns, path, [ignored, unignored]]) => {
   })
 })
 
+// A bracket expression is held aside behind a NUL placeholder while the
+// pattern is compiled, so a NUL written in the pattern itself must not be
+// mistaken for one of those placeholders
+_test('a literal NUL is not a bracket placeholder', t => {
+  const ig = ignore().add('a\u00000\u0000[bc]')
+
+  t.equal(ig.ignores('a\u00000\u0000b'), true)
+  t.equal(ig.ignores('a\u00000\u0000c'), true)
+  t.equal(ig.ignores('a\u00000\u0000d'), false)
+  t.equal(ig.ignores('[bc]'), false)
+
+  t.end()
+})
+
 _test('options.allowRelativePaths = true', t => {
   const ig = ignore({
     allowRelativePaths: true


### PR DESCRIPTION
## What is wrong

`[...]` is the one construct in the gitignore grammar with a sub-grammar of its own.
`index.js` locates *and* translates it with a single regular expression:

```js
/(\\)?\[([^\]/]*?)(\\*)($|\])/g
```

which stops at the first `]` and hands the body straight to `RegExp`, so JavaScript's
character-class rules end up interpreting it instead of fnmatch(3)'s. That one shortcut
is behind every divergence below, and it goes wrong in both directions.

Under-matching, so a file the user meant to ignore gets committed or published:

```js
const ignore = require('ignore')
const ig = p => ignore({ignorecase: false}).add(p)

ig('*.[[:digit:]]').ignores('a.5')   // false, git ignores it
ig('*.[]]').ignores('a.]')           // false, git ignores it
ig('*.[\\]]').ignores('a.]')         // false, git ignores it
ig('*.[*]').ignores('a.*')           // false, git ignores it
ig('x[?]y').ignores('x?y')           // false, git ignores it
```

Over-matching, so a file git tracks disappears from the working set:

```js
ig('*.[[:alpha:]]').ignores('a.l]')  // true, git does not
ig('x[\\^]y').ignores('xay')         // true, git does not
ig('*.[[:foo:]]').ignores('a.f]')    // true, git does not
```

Ground truth for the first and the last of those, git 2.50.1:

```
$ printf '*.[[:digit:]]\n' > .gitignore && git check-ignore -q a.5; echo $?
0
$ printf '*.[[:foo:]]\n' > .gitignore && git check-ignore -q 'a.f]'; echo $?
1
```

## How far it goes

I ran the whole bracket surface through a differential harness against real git:
`check-ignore -z -v --non-matching --stdin` so that git answers exactly once per query
and a skipped path can never be scored as agreement, cross-checked against plain
`check-ignore -z --stdin` for the boolean, with `core.ignorecase` forced off and asserted
to have taken effect (on APFS it defaults to on and case-folds every match).

114 patterns x 84 names: all twelve POSIX classes, their negated forms, classes mixed
with literals / ranges / other classes, malformed and unknown class names, `]` as the
first member, backslash escapes, regex metacharacters as members, `[` as a member,
hyphen corner cases, and unterminated forms.

**49 of the 114 patterns disagree with master** — 45 of them under-match, 31 over-match,
several do both on different names. With this change: 0.

They are not 49 bugs. They are one bug: nothing scans the class.

## The change

`extractBrackets()` walks the raw pattern, hands each `[...]` to `scanBracket()` and
leaves a placeholder behind. The replacer chain runs on that, and the translated classes
go back in at the end, so the metacharacter escaper and the `?` / `*` replacers never see
a class body — which is what was corrupting `[*]` and `[?]` in the first place.

`scanBracket()` follows the member loop of git's `wildmatch.c`: the do-while that consumes
the first member unconditionally (which is the whole `]`-as-first-member rule), the `-`
range test with its `prev_ch && p[1] != ']'` guard, the `[:` lookahead with its
"no `:]`, so treat it like a normal set" fallback, and `WM_ABORT_ALL` for an unterminated
expression or an unknown class name. `sanitizeRange` and `negateRange` are gone; the
scanner covers what they did.

Four details worth calling out, each observed rather than assumed:

- git classifies with its own ASCII-only ctype macros in `wildmatch.c`, so `[[:digit:]]`
  must not become `\d` and `[[:space:]]` must not become `\s` — the JS shorthands are
  Unicode-aware and would over-match. Every class is expanded to explicit ASCII ranges.
- `sane-ctype.h` files `\v` and `\f` under control rather than space, unlike C's
  `isspace`, so `[[:space:]]` is ` \t\n\r`. I only caught this because the harness has
  `\v` and `\f` in its name set.
- no expansion contains `/`, because a bracket expression never matches a path separator.
  `[[:print:]]` and `[[:punct:]]` would otherwise.
- an out-of-order range matches nothing in git, but its lower bound is still tested as a
  plain member before the `-` is looked at, so `[c-a]` does match `c`. The existing
  `*.[a-9]` fixture had that gap; it now also asserts that `a.a` is ignored, which real
  git confirms.

## Tests

The new fixtures sit next to the existing range-notation ones, so
`test/git-check-ignore.test.js` re-runs every one of them against the real `git` binary.
None of the expectations are hand-written: each is what `git check-ignore` answered.

`npm test` goes from 938 to 1157 passing assertions, coverage stays at 100%, lint is
clean, and `npm run test:win32` passes as well (1171).

I also mutated the scanner in both directions — 13 mutants, one per rule it implements,
including over-fixes such as emitting an out-of-order range anyway and letting a leading
`]` terminate the expression. All 13 are caught by the new fixtures.

## Not in scope

Two things this deliberately leaves alone, both pre-existing and independent of how the
class body is read:

- a positive range that spans `/`, e.g. `a[.-0]c`, still matches `a/c`.
- matching is per JavaScript character while git matches bytes, so a non-ASCII name in a
  negated class still differs.

Related: #155 lists `[!]` among several gitignore divergences. That one is a bracket
expression too, so the scanner settles it, and it is covered by a fixture. The other four
cases in that issue are elsewhere in the grammar and are untouched here.
