### PR TITLE
fix: a trailing '/**/' should not ignore a direct file

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,12 +216,20 @@ const REPLACERS = [
     // Check if it is not the last `'/**'`
     (_, index, str) => index + 6 < str.length
 
-      // case: /**/
-      // > A slash followed by two consecutive asterisks then a slash matches
-      // >   zero or more directories.
-      // > For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b" and so on.
-      // '/**/'
-      ? '(?:\\/[^\\/]+)*'
+      // case: /**/ at the end of the pattern, i.e. a trailing `'/**/'`
+      // > A trailing `"/**/"` (a trailing `"/**"` restricted to directories)
+      // >   matches everything inside, but it should not match the current
+      // >   folder itself, so it requires at least one directory segment.
+      // 'a/**/' matches 'a/b/', 'a/x/y/' but not 'a/'
+      ? str.slice(index + 6) === '\\/'
+        ? '(?:\\/[^\\/]+)+'
+
+        // case: /**/
+        // > A slash followed by two consecutive asterisks then a slash matches
+        // >   zero or more directories.
+        // > For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b" and so on.
+        // '/**/'
+        : '(?:\\/[^\\/]+)*'
 
       // case: /**
       // > A trailing `"/**"` matches everything inside.

--- a/test/fixtures/cases.js
+++ b/test/fixtures/cases.js
@@ -932,6 +932,19 @@ const cases = [
   ],
 
   [
+    'A trailing "/**/" matches directories inside but not the parent folder itself',
+    [
+      'a/**/'
+    ],
+    {
+      'a/f.txt': 0,
+      'a/b/': 1,
+      'a/b/f.txt': 1,
+      'a/deep/nested/x.txt': 1
+    }
+  ],
+
+  [
     'add a file content',
     readPatterns('.aignore'),
     {


### PR DESCRIPTION
A trailing `/**/` over-ignores a direct **file** that git keeps:

```
# .gitignore
a/**/
```

```js
const ig = ignore().add('a/**/');
ig.ignores('a/f.txt');    // true  — but `git check-ignore a/f.txt` says NOT ignored
ig.ignores('a/b/f.txt');  // true  — correct
ig.ignores('a/b/');       // true  — correct
```

Verified against the real git binary (`git check-ignore` / `git status --ignored`): `a/f.txt` is **not** ignored, only entries under a subdirectory are. Because `checkIgnore()` is documented as imitating `git check-ignore`, this is a contract violation, not just an `ignores()` quirk.

## Cause

`a/**/` compiled to `^a(?:\/[^\/]+)*\/$`. The `(?:…)*` (zero-or-more) also matches the parent `a/`, and the parent-directory cascade then ignores everything directly under `a`.

## Fix

A trailing `/**/` restricts the match to directories and must not match the folder itself, so it requires at least one directory segment. In the two-globstar replacer, detect the trailing case (`str.slice(index + 6) === '\\/'`) and emit `(?:\/[^\/]+)+` (one-or-more) instead of `*`:

- `a/**/` → matches `a/b/`, `a/x/y/`, not `a/` (so `a/f.txt` is no longer ignored)
- `a/**/b` (middle) is unchanged — zero-or-more is correct there, `a/b` must match
- `a/**` (trailing, no slash) and leading `**/` are unchanged

## Tests

A fixture added to `test/fixtures/cases.js` in the existing format; it passes all harness variants including the live `git check-ignore --no-index` validation, and fails on the current code. The full suite otherwise passes (the single unrelated `#76` literal-`#` case fails on unmodified `main` too).
